### PR TITLE
Add machine-checked documentation for ToJSON instances

### DIFF
--- a/Data/Aeson/IP.hs
+++ b/Data/Aeson/IP.hs
@@ -25,6 +25,10 @@ instance FromJSONKey IPv4 where
                           Just r -> pure r
                           Nothing -> fail "Unable to parse IPv4"
 
+-- | The @ToJSON@ instance produces JSON strings matching the @Show@ instance.
+-- 
+-- >>> toJSON (toIPv4 [127,0,0,1])
+-- String "127.0.0.1"
 instance ToJSON IPv4 where
     toJSON = String . Text.pack . show
 
@@ -43,6 +47,10 @@ instance FromJSONKey IPv6 where
                           Just r -> pure r
                           Nothing -> fail "Unable to parse IPv6"
 
+-- | The @ToJSON@ instance produces JSON strings matching the @Show@ instance.
+-- 
+-- >>> toJSON (toIPv6 [0x2001,0xDB8,0,0,0,0,0,1])
+-- String "2001:db8::1"
 instance ToJSON IPv6 where
     toJSON = String . Text.pack . show
 

--- a/aeson-iproute.cabal
+++ b/aeson-iproute.cabal
@@ -29,3 +29,12 @@ library
 source-repository head
   type: git
   location: https://github.com/greydot/aeson-iproute.git
+
+test-suite doctest
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              doctests.hs
+  build-depends:        base >= 4.6 && < 5,
+                        doctest >= 0.9.3
+
+  default-language:     Haskell2010

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Test.DocTest
+
+main :: IO ()
+main = doctest ["Data/Aeson/IP.hs"]


### PR DESCRIPTION
It's useful to see what format is produced by ToJSON instances and expected by FromJSON instances. This patch adds that.

Approach based on how `Show` instances are documented in `iproute` itself.